### PR TITLE
Add basic debian support

### DIFF
--- a/cook.cabal
+++ b/cook.cabal
@@ -34,6 +34,7 @@ library
                      , Cook.Catalog.SSH
                      , Cook.Catalog.Sudo
                      , Cook.Catalog.Arch.Pacman
+                     , Cook.Catalog.Debian.Apt
                      , Cook.Catalog.Systemd
                      , Cook.Catalog.Systemd.Container
                      , Cook.Catalog.User

--- a/src/Cook/Catalog/Debian/Apt.hs
+++ b/src/Cook/Catalog/Debian/Apt.hs
@@ -1,0 +1,27 @@
+module Cook.Catalog.Debian.Apt (
+    installPackages
+  , updatePackages
+  , upgradePackages
+  ) where
+
+import Data.List.NonEmpty
+import Data.Semigroup
+
+import Cook.Recipe
+
+aptGet :: NonEmpty String -> Step
+aptGet args = procEnv "apt-get" args' env
+  where env = Just [("DEBIAN_FRONTEND", "noninteractive")]
+        args' = toList $ ["-q", "-y"] <> args
+
+installPackages :: NonEmpty String -> Recipe ()
+installPackages pkgs = withRecipeName "Debian.Apt.InstallPackages" $ do
+  run $ aptGet $ ["install"] <> pkgs
+
+updatePackages :: Recipe ()
+updatePackages = withRecipeName "Debian.Apt.UpdatePackages" $ do
+  run $ aptGet $ ["update"]
+
+upgradePackages :: Recipe ()
+upgradePackages = withRecipeName "Debian.Apt.UpgradePackages" $ do
+  run $ aptGet $ ["upgrade"]

--- a/src/Cook/Recipe.hs
+++ b/src/Cook/Recipe.hs
@@ -99,7 +99,7 @@ data Step = Proc FilePath [String] (Maybe Environment)
           | Failure String
 
 instance Show Step where
-    show (Proc prog args env) = printf "process: %s %s %s %s" (showEnv env) prog (unwords args)
+    show (Proc prog args env) = printf "process: %s %s %s" (showEnv env) prog (unwords args)
       where showEnv = maybe "" (unwords . map (\(k, v) -> k <> "=" <> v))
     show (Shell cmd)          = printf "shell:   %s" cmd
     show (Failure msg)        = printf "failure: %s" msg

--- a/src/Cook/Recipe.hs
+++ b/src/Cook/Recipe.hs
@@ -99,7 +99,7 @@ data Step = Proc FilePath [String] (Maybe Environment)
           | Failure String
 
 instance Show Step where
-    show (Proc prog args env) = printf "process: %s %s %s" prog (unwords args) (showEnv env)
+    show (Proc prog args env) = printf "process: %s %s %s %s" (showEnv env) prog (unwords args)
       where showEnv = maybe "" (unwords . map (\(k, v) -> k <> "=" <> v))
     show (Shell cmd)          = printf "shell:   %s" cmd
     show (Failure msg)        = printf "failure: %s" msg

--- a/src/Cook/Recipe.hs
+++ b/src/Cook/Recipe.hs
@@ -6,6 +6,7 @@ module Cook.Recipe (
 
   , proc
   , proc'
+  , procEnv
   , sh
 
   , run
@@ -91,7 +92,9 @@ type Code = Int
 
 type Recipe = ExceptT (Trace, Code) (StateT Ctx IO)
 
-data Step = Proc FilePath [String] (Maybe [(String, String)])
+type Environment = [(String, String)]
+
+data Step = Proc FilePath [String] (Maybe Environment)
           | Shell String
           | Failure String
 
@@ -124,6 +127,9 @@ proc p a = Proc p a Nothing
 
 proc' :: FilePath -> Step
 proc' prog = Proc prog [] Nothing
+
+procEnv :: FilePath -> [String] -> Maybe Environment -> Step
+procEnv = Proc
 
 sh :: String -> Step
 sh = Shell

--- a/test/TestRecipe.hs
+++ b/test/TestRecipe.hs
@@ -1,10 +1,12 @@
 import Control.Monad.IO.Class
 import Data.Text.Lazy
 
+import Data.List.NonEmpty
 import qualified Data.Text.Lazy.IO as T
 
 import Cook.Recipe
 import Cook.Catalog.Systemd.Container
+import Cook.Catalog.Debian.Apt as Apt
 import Cook.Catalog.Cjdns
 
 main :: IO ()


### PR DESCRIPTION
I've added really basic `Apt` module. Unfortunately I have to use environment variable to force non interactive mode on `apt`, so I've added additional field for `env` to `Proc` type and `procEnv` constructor (I'm not really proud of this name).

I've tried to keep your coding style.
